### PR TITLE
fix(i18n): sync overlay with theme upstream

### DIFF
--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -93,6 +93,7 @@ commons:
     website: Website
     web: Web
     schedule: Hours
+    socials: Social Media
   credit: A low impact website crafted with <a href="https://www.osuny.org/" title="Osuny - extern link" target="_blank" rel="noreferrer">Osuny</a>
   date: Date
   download:
@@ -177,7 +178,7 @@ events:
   from:
     day: From day
     hour: From hour
-  share: Partager sur
+  share: Share on
   to:
     day: To day
     hour: To hour


### PR DESCRIPTION
This brings new and updated keys from the theme's English translation file into our fork with different namings for `commons.contact.address` and `commons.contact.phone_professional`.

Adds `commons.contact.social` and updates `events.share`.

Derived with:

    diff i18n/en.yml themes/osuny/i18n/en.yml